### PR TITLE
Add wage-age spline model

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
 #Mateo Tareas Puce
+## Análisis de edad e ingreso
+
+El script `wage_age_analysis.R` carga la base `salarios_edad.csv` empleando rutas robustas con el paquete **here**.
+Realiza las gráficas con **ggplot2**, ajusta un modelo lineal y otro cuadrático,
+y calcula apalancamiento y residuos estandarizados.
+
+El archivo `spline_wage_age.R` aplica splines suavizados sobre la misma data.
+Explora distintos valores del parámetro de suavizado (lambda) y distintos grados
+ de libertad usando `smooth.spline`. Se escogen los mejores modelos por
+criterio de validación cruzada y se visualizan ambos ajustes con **ggplot2**.

--- a/spline_wage_age.R
+++ b/spline_wage_age.R
@@ -1,0 +1,56 @@
+# Modelo spline suavizado para relacion edad-ingreso
+
+# Cargar librerias
+library(readr)
+library(ggplot2)
+
+# Ruta robusta al archivo
+# Cambia "salarios_edad.csv" si el nombre es diferente
+
+ruta <- here::here("salarios_edad.csv")
+df <- read_csv(ruta)
+
+# --------------------------
+# Buscar mejor modelo por lambda (spar)
+# --------------------------
+lambdas <- seq(0, 1, length.out = 6)
+fits_lambda <- lapply(lambdas, function(l) {
+  smooth.spline(df$age, df$wage, spar = l, cv = TRUE)
+})
+cv_lambda <- sapply(fits_lambda, function(f) f$cv.crit)
+best_lambda <- lambdas[which.min(cv_lambda)]
+best_fit_lambda <- fits_lambda[[which.min(cv_lambda)]]
+
+# --------------------------
+# Buscar mejor modelo por grados de libertad
+# --------------------------
+dfs <- 3:8
+fits_df <- lapply(dfs, function(d) {
+  smooth.spline(df$age, df$wage, df = d, cv = TRUE)
+})
+cv_df <- sapply(fits_df, function(f) f$cv.crit)
+best_df <- dfs[which.min(cv_df)]
+best_fit_df <- fits_df[[which.min(cv_df)]]
+
+cat("Mejor lambda:", round(best_lambda, 3), "CV:", round(min(cv_lambda), 3), "\n")
+cat("Mejor grados de libertad:", best_df, "CV:", round(min(cv_df), 3), "\n")
+
+# --------------------------
+# Visualizacion de los ajustes
+# --------------------------
+age_grid <- seq(min(df$age), max(df$age), length.out = 100)
+
+pred_lambda <- predict(best_fit_lambda, age_grid)
+pred_df <- predict(best_fit_df, age_grid)
+
+plot_data <- rbind(
+  data.frame(age = age_grid, wage = pred_lambda$y, modelo = "Lambda"),
+  data.frame(age = age_grid, wage = pred_df$y, modelo = "GradosLibertad")
+)
+
+ggplot(df, aes(age, wage)) +
+  geom_point(alpha = 0.4) +
+  geom_line(data = plot_data, aes(age, wage, colour = modelo,
+                                  linetype = modelo)) +
+  labs(title = "Modelos Spline suavizados", x = "Edad",
+       y = "Ingreso por hora")

--- a/wage_age_analysis.R
+++ b/wage_age_analysis.R
@@ -1,0 +1,56 @@
+# Analisis no lineal de edad e ingreso por hora
+
+# Cargar librerias
+library(readr)
+library(ggplot2)
+
+# ruta robusta al archivo
+# cambia "salarios_edad.csv" si el nombre del archivo es diferente
+df <- read_csv(here::here("salarios_edad.csv"))
+
+# Vista preliminar
+head(df)
+
+# Correlacion age-wage
+correlacion <- cor(df$age, df$wage, use = "complete.obs")
+cat("La correlacion entre edad e ingreso por hora es:", round(correlacion,3),"\n")
+
+# Diagrama de dispersion
+p1 <- ggplot(df, aes(age, wage)) +
+  geom_point(alpha = 0.5) +
+  labs(title = "Relacion entre Edad y Salario por Hora",
+       x = "Edad", y = "Ingreso por hora")
+print(p1)
+
+# Modelo lineal y residuos estandarizados
+modelo <- lm(wage ~ age, data = df)
+residuos_std <- rstandard(modelo)
+
+ggplot(data.frame(age = df$age, resid = residuos_std), aes(age, resid)) +
+  geom_point(alpha = 0.5, colour = "red") +
+  geom_hline(yintercept = c(-2,0,2), linetype = "dashed",
+             colour = c("red","black","red")) +
+  labs(title = "Residuos estandarizados del modelo lineal",
+       x = "Edad", y = "Residuos estandarizados")
+
+# Resumen del modelo lineal
+print(summary(modelo))
+
+# Analisis de apalancamiento
+apalancamiento <- hatvalues(modelo)
+
+n <- nrow(df)
+p <- 2
+umbral <- 2 * p / n
+
+df_bajo_apalancamiento <- df[apalancamiento < umbral,]
+
+cat("Umbral de apalancamiento:", round(umbral,5),"\n")
+cat("Observaciones con bajo apalancamiento:", nrow(df_bajo_apalancamiento),
+    "de", n, "\n")
+head(df_bajo_apalancamiento)
+
+# Modelo no lineal con termino cuadratico
+modelo_quad <- lm(wage ~ age + I(age^2), data = df)
+print(summary(modelo_quad))
+


### PR DESCRIPTION
## Summary
- document smoothing spline analysis in README
- add `spline_wage_age.R` to explore lambda and df for smoothing splines

## Testing
- `R --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6875b900025083259c4663ac8bc50608